### PR TITLE
docs: add fallback for `monospace` fonts

### DIFF
--- a/assets/stylesheets/print.css
+++ b/assets/stylesheets/print.css
@@ -81,7 +81,7 @@ header h2 {
 }
 
 code, pre {
-  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   color: #222;
   margin-bottom: 30px;
   font-size: 12px;

--- a/assets/stylesheets/stylesheet.css
+++ b/assets/stylesheets/stylesheet.css
@@ -170,7 +170,7 @@ a.button span {
 }
 
 code, pre {
-  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   color: #222;
   margin-bottom: 30px;
   font-size: 14px;


### PR DESCRIPTION
The current CSS doesn't provide a `monospace` fallback in some cases,
only using named fonts, which leads to systems without these fonts
not presenting code snippets as monospaced.

On some pages i.e. [0], we see the below:

![2024-10-13-144609_845x371_scrot](https://github.com/user-attachments/assets/97677c85-86d3-4a5f-8af5-84a3b8b8f002)


[0]: https://docs.joind.in/joindin-api/events.html

